### PR TITLE
Bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
 	"name": "39bot",
 	"version": "0.0.1",
-	"lockfileVersion": 2,
+	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "39bot",
 			"version": "0.0.1",
 			"dependencies": {
-				"discord.js": "*",
+				"discord.js": "dev",
 				"mongoose": "8.8.3",
 				"strife.js": "4.1.5"
 			},
@@ -30,6 +30,7 @@
 			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.9.1-dev.1727784293-b20346f43.tgz",
 			"integrity": "sha512-CDy8PSqUiargLggQ/eRydWqTOrj1AWkDN+uUYL28/aTexjCnlZ/m4sLMCc7eAECSfBzEB5Qg6xpu68rgKGjjNw==",
 			"deprecated": "This version is deprecated. Please use a newer version.",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@discordjs/formatters": "^0.5.0",
 				"@discordjs/util": "^1.1.1",
@@ -46,80 +47,101 @@
 				"url": "https://github.com/discordjs/discord.js?sponsor"
 			}
 		},
-		"node_modules/@discordjs/builders/node_modules/discord-api-types": {
-			"version": "0.37.103",
-			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.103.tgz",
-			"integrity": "sha512-r+qitxXKe2l6KFw5odPdZSSqdEou+7eNC7BfbZ7mny5Me/K06wCTeKUMVeH/YsI9+4QQudskeQ307kr/7ppQ1A=="
-		},
 		"node_modules/@discordjs/collection": {
 			"version": "1.6.0-dev.1699315767-344a3f934",
 			"resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.6.0-dev.1699315767-344a3f934.tgz",
 			"integrity": "sha512-XBKQBrCzWYIvWHVGNLVlfvbSJtLzBV+bS22xhfG7mpVyfwOfXEZTHPcChEm4RTYy711MzY3MD/6vMyD+lQ7p+A==",
 			"deprecated": "This version is deprecated. Please use a newer version.",
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=16.11.0"
 			}
 		},
 		"node_modules/@discordjs/formatters": {
-			"version": "0.5.0-dev.1724803866-a5afc406b",
-			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.5.0-dev.1724803866-a5afc406b.tgz",
-			"integrity": "sha512-4jXyUPQ6cxux/p4Hqi/dSig5y2VGMqGRT7fJQgairV6CQoNR4sAbrjUltVkS5cDRPj7d2/kvkYCh7lrusGulTA==",
+			"version": "1.0.0-dev.1732795526-2b0944a92",
+			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-1.0.0-dev.1732795526-2b0944a92.tgz",
+			"integrity": "sha512-uYMEK/vmJebsABex0wPtfi0k5P4zgZyC7yCeHEbYHbt0bnksKy62yc+/9NLzd9egE6iZiRiS7a4ymUG4QHE7xw==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"discord-api-types": "0.37.97"
+				"discord-api-types": "^0.37.109"
 			},
 			"engines": {
-				"node": ">=16.11.0"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/discordjs/discord.js?sponsor"
 			}
 		},
 		"node_modules/@discordjs/rest": {
-			"version": "2.4.0-dev.1724803854-a5afc406b",
-			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.4.0-dev.1724803854-a5afc406b.tgz",
-			"integrity": "sha512-wEqgjZQdeJhabpyqWIFv5mkVRIj0zD+jig9BeCC+ZQitC52a3W5G0MGvoRRdmRYPW3nE2f2nhJedjY/cJ5Wc1A==",
+			"version": "3.0.0-dev.1732795513-2b0944a92",
+			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-3.0.0-dev.1732795513-2b0944a92.tgz",
+			"integrity": "sha512-tq3CPZItvg4Mra4Iab0wC1/dffK+4BqxR/uOa2fcejWj/PIzjzvpXFtQqEjD8P0GB2Zhi6CC0Ixd8TNKussn2Q==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@discordjs/collection": "^2.1.0",
-				"@discordjs/util": "^1.1.0",
-				"@sapphire/async-queue": "^1.5.3",
-				"@sapphire/snowflake": "^3.5.3",
+				"@discordjs/collection": "^2.1.1",
+				"@discordjs/util": "^1.1.1",
+				"@sapphire/async-queue": "^1.5.5",
+				"@sapphire/snowflake": "^3.5.5",
 				"@vladfrangu/async_event_emitter": "^2.4.6",
-				"discord-api-types": "0.37.97",
+				"discord-api-types": "^0.37.109",
 				"magic-bytes.js": "^1.10.0",
-				"tslib": "^2.6.3",
-				"undici": "6.19.8"
+				"tslib": "^2.8.1",
+				"undici": "6.21.0"
 			},
 			"engines": {
-				"node": ">=16.11.0"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/discordjs/discord.js?sponsor"
-			}
-		},
-		"node_modules/@discordjs/rest/node_modules/@sapphire/snowflake": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
-			"integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
-			"engines": {
-				"node": ">=v14.0.0",
-				"npm": ">=7.0.0"
 			}
 		},
 		"node_modules/@discordjs/util": {
-			"version": "1.1.1-dev.1724803860-a5afc406b",
-			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.1-dev.1724803860-a5afc406b.tgz",
-			"integrity": "sha512-v0/HLJgNAX1C3SISnQ6Z5lpQ7+NrsdWCR+QoVnVbDUqLGmeCZD7iegLby4uUemasxTFXVM6SdQrNUM9lAiEEvw==",
+			"version": "2.0.0-dev.1732795513-2b0944a92",
+			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-2.0.0-dev.1732795513-2b0944a92.tgz",
+			"integrity": "sha512-Nc0XtAD2fnZkxrIe61SAxfDG2Nt0kvOqI8lbF5g8fjqJPU4c+T/9wlClHWORzPEUn0lZoQ8XAg5Oc8MgzZxRQQ==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/discordjs/discord.js?sponsor"
+			}
+		},
+		"node_modules/@discordjs/ws": {
+			"version": "1.2.0-dev.1721822666-fcd35ea2e",
+			"resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.0-dev.1721822666-fcd35ea2e.tgz",
+			"integrity": "sha512-AEck4R1oBztXXoRsVW8mYj8ZLJHSzo1W+erbHmatLk/qHWV3ni2mtCpGWM+j1OePLO4Ab9ii1K5kgW7WfeFgsQ==",
+			"deprecated": "This version is deprecated. Please use a newer version.",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@discordjs/collection": "^2.1.0",
+				"@discordjs/rest": "^2.3.0",
+				"@discordjs/util": "^1.1.0",
+				"@sapphire/async-queue": "^1.5.2",
+				"@types/ws": "^8.5.10",
+				"@vladfrangu/async_event_emitter": "^2.2.4",
+				"discord-api-types": "0.37.90",
+				"tslib": "^2.6.2",
+				"ws": "^8.17.0"
+			},
 			"engines": {
 				"node": ">=16.11.0"
 			},
 			"funding": {
 				"url": "https://github.com/discordjs/discord.js?sponsor"
 			}
+		},
+		"node_modules/@discordjs/ws/node_modules/discord-api-types": {
+			"version": "0.37.90",
+			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.90.tgz",
+			"integrity": "sha512-lpOJSGrqHuXoM4FV/2HtjoaJpCClGFHpRNIdZEW8zPINlsCHNSfIwA2EQ8dxeE6k1QhhTuM9ZlOGVYXoU7FLgA==",
+			"license": "MIT"
 		},
 		"node_modules/@mongodb-js/saslprep": {
 			"version": "1.1.9",
 			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.9.tgz",
 			"integrity": "sha512-tVkljjeEaAhCqTzajSdgbQ6gE6f3oneVwa3iXR6csiEwXXOFsiC6Uh9iAjAhXPtqa/XMDHWjjeNH/77m/Yq2dw==",
+			"license": "MIT",
 			"dependencies": {
 				"sparse-bitfield": "^3.0.3"
 			}
@@ -130,6 +152,7 @@
 			"integrity": "sha512-MJ8xV9ntgtpqsu9xXryY9WbADXxXRxf1AvsoQuWeH+uVGQD/E+65HXNKO2BcArbb6b8AIIh6/NF9NejMoy4wdQ==",
 			"dev": true,
 			"hasShrinkwrap": true,
+			"license": "MIT",
 			"dependencies": {
 				"prettier-plugin-ini": "1.2.0",
 				"prettier-plugin-jsdoc": "1.3.0",
@@ -1236,9 +1259,10 @@
 			"dev": true
 		},
 		"node_modules/@sapphire/async-queue": {
-			"version": "1.5.3",
-			"resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.3.tgz",
-			"integrity": "sha512-x7zadcfJGxFka1Q3f8gCts1F0xMwCKbZweM85xECGI0hBTeIZJGGCrHgLggihBoprlQ/hBmDR5LKfIPqnmHM3w==",
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+			"integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=v14.0.0",
 				"npm": ">=7.0.0"
@@ -1248,6 +1272,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
 			"integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"lodash": "^4.17.21"
@@ -1256,16 +1281,28 @@
 				"node": ">=v16"
 			}
 		},
+		"node_modules/@sapphire/snowflake": {
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
+			"integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=v14.0.0",
+				"npm": ">=7.0.0"
+			}
+		},
 		"node_modules/@total-typescript/ts-reset": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/@total-typescript/ts-reset/-/ts-reset-0.6.1.tgz",
 			"integrity": "sha512-cka47fVSo6lfQDIATYqb/vO1nvFfbPw7uWLayIXIhGETj0wcOOlrlkobOMDNQOFr9QOafegUPq13V2+6vtD7yg==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/node": {
 			"version": "20.10.8",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.8.tgz",
 			"integrity": "sha512-f8nQs3cLxbAFc00vEU59yf9UyGUftkPaLGfvbVOIDdx2i1b8epBqj2aNGyP19fiyXWvlmZ7qC1XLjAzw/OKIeA==",
+			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~5.26.4"
 			}
@@ -1273,20 +1310,23 @@
 		"node_modules/@types/webidl-conversions": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
-			"integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="
+			"integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+			"license": "MIT"
 		},
 		"node_modules/@types/whatwg-url": {
 			"version": "11.0.5",
 			"resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
 			"integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+			"license": "MIT",
 			"dependencies": {
 				"@types/webidl-conversions": "*"
 			}
 		},
 		"node_modules/@types/ws": {
-			"version": "8.5.12",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.12.tgz",
-			"integrity": "sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==",
+			"version": "8.5.13",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.13.tgz",
+			"integrity": "sha512-osM/gWBTPKgHV8XkTunnegTRIsvF6owmf5w+JtAfOw472dptdm0dlGv4xCt6GwQRcC2XVOvvRE/0bAoQcL2QkA==",
+			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*"
 			}
@@ -1295,6 +1335,7 @@
 			"version": "2.4.6",
 			"resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.6.tgz",
 			"integrity": "sha512-RaI5qZo6D2CVS6sTHFKg1v5Ohq/+Bo2LZ5gzUEwZ/WkHhwtGTCB/sVLw8ijOkAUxasZ+WshN/Rzj4ywsABJ5ZA==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=v14.0.0",
 				"npm": ">=7.0.0"
@@ -1305,6 +1346,7 @@
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
 			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"normalize-path": "^3.0.0",
 				"picomatch": "^2.0.4"
@@ -1317,13 +1359,15 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/binary-extensions": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
 			"integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			},
@@ -1336,6 +1380,7 @@
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -1346,6 +1391,7 @@
 			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
 			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"fill-range": "^7.1.1"
 			},
@@ -1354,9 +1400,10 @@
 			}
 		},
 		"node_modules/bson": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/bson/-/bson-6.9.0.tgz",
-			"integrity": "sha512-X9hJeyeM0//Fus+0pc5dSUMhhrrmWwQUtdavaQeF3Ta6m69matZkGWV/MrBcnwUeLC8W9kwwc2hfkZgUuCX3Ig==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/bson/-/bson-6.10.0.tgz",
+			"integrity": "sha512-ROchNosXMJD2cbQGm84KoP7vOGPO6/bOAW0veMMbzhXLqoZptcaYRVLitwvuhwhjjpU1qP4YZRWLhgETdgqUQw==",
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=16.20.1"
 			}
@@ -1366,6 +1413,7 @@
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
 			"integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"anymatch": "~3.1.2",
 				"braces": "~3.0.2",
@@ -1389,14 +1437,16 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/debug": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-			"integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+			"version": "4.3.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+			"integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+			"license": "MIT",
 			"dependencies": {
-				"ms": "2.1.2"
+				"ms": "^2.1.3"
 			},
 			"engines": {
 				"node": ">=6.0"
@@ -1407,87 +1457,50 @@
 				}
 			}
 		},
-		"node_modules/debug/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-		},
 		"node_modules/discord-api-types": {
-			"version": "0.37.97",
-			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.97.tgz",
-			"integrity": "sha512-No1BXPcVkyVD4ZVmbNgDKaBoqgeQ+FJpzZ8wqHkfmBnTZig1FcH3iPPersiK1TUIAzgClh2IvOuVUYfcWLQAOA=="
+			"version": "0.37.109",
+			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.109.tgz",
+			"integrity": "sha512-B4W/ao8vempNVCS4/K4CeeCGhiabTcU7ekgqJy4/RytEsgkJP9hWS0MWZMcRP3wWzU/FXi6QqqvArZTJUfc6Iw==",
+			"license": "MIT"
 		},
 		"node_modules/discord.js": {
-			"version": "14.16.0-dev.1724544741-437437461",
-			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.16.0-dev.1724544741-437437461.tgz",
+			"version": "15.0.0-dev.1732795515-2b0944a92",
+			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-15.0.0-dev.1732795515-2b0944a92.tgz",
+			"integrity": "sha512-CUVnDcgjcDA1KvhVl+85cXDkNNtd4xX1VL+33CjRwVs0BGUAOaUqkctD0/N9ZRMaNd4NB2dXn6dRbY8JTJK+9g==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@discordjs/builders": "^1.8.2",
+				"@discordjs/builders": "^1.9.0",
 				"@discordjs/collection": "1.5.3",
-				"@discordjs/formatters": "^0.4.0",
-				"@discordjs/rest": "^2.3.0",
-				"@discordjs/util": "^1.1.0",
-				"@discordjs/ws": "1.1.1",
-				"@sapphire/snowflake": "3.5.3",
-				"discord-api-types": "0.37.97",
+				"@discordjs/formatters": "^0.5.0",
+				"@discordjs/rest": "^2.4.0",
+				"@discordjs/util": "^1.1.1",
+				"@discordjs/ws": "^2.0.0",
+				"@sapphire/snowflake": "3.5.5",
+				"discord-api-types": "^0.37.109",
 				"fast-deep-equal": "3.1.3",
 				"lodash.snakecase": "4.1.1",
-				"tslib": "^2.6.3",
-				"undici": "6.19.8"
+				"tslib": "^2.8.1",
+				"undici": "6.21.0"
 			},
 			"engines": {
-				"node": ">=16.11.0"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/discordjs/discord.js?sponsor"
-			}
-		},
-		"node_modules/discord.js/node_modules/@discordjs/ws": {
-			"version": "1.2.0-dev.1721822666-fcd35ea2e",
-			"resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.0-dev.1721822666-fcd35ea2e.tgz",
-			"integrity": "sha512-AEck4R1oBztXXoRsVW8mYj8ZLJHSzo1W+erbHmatLk/qHWV3ni2mtCpGWM+j1OePLO4Ab9ii1K5kgW7WfeFgsQ==",
-			"deprecated": "This version is deprecated. Please use a newer version.",
-			"dependencies": {
-				"@discordjs/collection": "^2.1.0",
-				"@discordjs/rest": "^2.3.0",
-				"@discordjs/util": "^1.1.0",
-				"@sapphire/async-queue": "^1.5.2",
-				"@types/ws": "^8.5.10",
-				"@vladfrangu/async_event_emitter": "^2.2.4",
-				"discord-api-types": "0.37.90",
-				"tslib": "^2.6.2",
-				"ws": "^8.17.0"
-			},
-			"engines": {
-				"node": ">=16.11.0"
-			},
-			"funding": {
-				"url": "https://github.com/discordjs/discord.js?sponsor"
-			}
-		},
-		"node_modules/discord.js/node_modules/@discordjs/ws/node_modules/discord-api-types": {
-			"version": "0.37.90",
-			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.90.tgz",
-			"integrity": "sha512-lpOJSGrqHuXoM4FV/2HtjoaJpCClGFHpRNIdZEW8zPINlsCHNSfIwA2EQ8dxeE6k1QhhTuM9ZlOGVYXoU7FLgA=="
-		},
-		"node_modules/discord.js/node_modules/@sapphire/snowflake": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
-			"integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
-			"engines": {
-				"node": ">=v14.0.0",
-				"npm": ">=7.0.0"
 			}
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"license": "MIT"
 		},
 		"node_modules/fill-range": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
 			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
 			},
@@ -1501,6 +1514,7 @@
 			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
 			"dev": true,
 			"hasInstallScript": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -1514,6 +1528,7 @@
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
 			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"is-glob": "^4.0.1"
 			},
@@ -1526,6 +1541,7 @@
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
@@ -1534,13 +1550,15 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
 			"integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/is-binary-path": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
 			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"binary-extensions": "^2.0.0"
 			},
@@ -1553,6 +1571,7 @@
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -1562,6 +1581,7 @@
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
 			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"is-extglob": "^2.1.1"
 			},
@@ -1574,6 +1594,7 @@
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
 			}
@@ -1582,6 +1603,7 @@
 			"version": "2.6.3",
 			"resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
 			"integrity": "sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==",
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=12.0.0"
 			}
@@ -1589,28 +1611,33 @@
 		"node_modules/lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"license": "MIT"
 		},
 		"node_modules/lodash.snakecase": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
-			"integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
+			"integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+			"license": "MIT"
 		},
 		"node_modules/magic-bytes.js": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.10.0.tgz",
-			"integrity": "sha512-/k20Lg2q8LE5xiaaSkMXk4sfvI+9EGEykFS4b0CHHGWqDYU0bGUFSwchNOMA56D7TCs9GwVTkqe9als1/ns8UQ=="
+			"integrity": "sha512-/k20Lg2q8LE5xiaaSkMXk4sfvI+9EGEykFS4b0CHHGWqDYU0bGUFSwchNOMA56D7TCs9GwVTkqe9als1/ns8UQ==",
+			"license": "MIT"
 		},
 		"node_modules/memory-pager": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
-			"integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="
+			"integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+			"license": "MIT"
 		},
 		"node_modules/minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -1622,6 +1649,7 @@
 			"version": "6.10.0",
 			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.10.0.tgz",
 			"integrity": "sha512-gP9vduuYWb9ZkDM546M+MP2qKVk5ZG2wPF63OvSRuUbqCR+11ZCAE1mOfllhlAG0wcoJY5yDL/rV3OmYEwXIzg==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@mongodb-js/saslprep": "^1.1.5",
 				"bson": "^6.7.0",
@@ -1667,6 +1695,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.1.tgz",
 			"integrity": "sha512-XqMGwRX0Lgn05TDB4PyG2h2kKO/FfWJyCzYQbIhXUxz7ETt0I/FqHjUeqj37irJ+Dl1ZtU82uYyj14u2XsZKfg==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@types/whatwg-url": "^11.0.2",
 				"whatwg-url": "^13.0.0"
@@ -1676,6 +1705,7 @@
 			"version": "8.8.3",
 			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.8.3.tgz",
 			"integrity": "sha512-/I4n/DcXqXyIiLRfAmUIiTjj3vXfeISke8dt4U4Y8Wfm074Wa6sXnQrXN49NFOFf2mM1kUdOXryoBvkuCnr+Qw==",
+			"license": "MIT",
 			"dependencies": {
 				"bson": "^6.7.0",
 				"kareem": "2.6.3",
@@ -1697,6 +1727,7 @@
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
 			"integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=4.0.0"
 			}
@@ -1705,6 +1736,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
 			"integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+			"license": "MIT",
 			"dependencies": {
 				"debug": "4.x"
 			},
@@ -1715,13 +1747,15 @@
 		"node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT"
 		},
 		"node_modules/nodemon": {
 			"version": "3.1.7",
 			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.7.tgz",
 			"integrity": "sha512-hLj7fuMow6f0lbB0cD14Lz2xNjwsyruH251Pk4t/yIitCFJbmY1myuLlHm/q06aST4jg6EgAh74PIBBrRqpVAQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"chokidar": "^3.5.2",
 				"debug": "^4",
@@ -1750,6 +1784,7 @@
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -1759,6 +1794,7 @@
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
 			},
@@ -1771,6 +1807,7 @@
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
 			"integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -1785,12 +1822,14 @@
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
 			"integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -1800,6 +1839,7 @@
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
 			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"picomatch": "^2.2.1"
 			},
@@ -1812,6 +1852,7 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
 			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
 			"dev": true,
+			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -1823,6 +1864,7 @@
 			"version": "11.0.3",
 			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-11.0.3.tgz",
 			"integrity": "sha512-2G2y++21dhj2R7iHAdd0FIzjGwuKZld+7Pl/bTU6YIkrC2ZMbVUjm+luj6A6V34Rv9XfKJDKpTWu9W4Gse1D9g==",
+			"license": "MIT",
 			"dependencies": {
 				"type-fest": "^2.12.2"
 			},
@@ -1836,13 +1878,15 @@
 		"node_modules/sift": {
 			"version": "17.1.3",
 			"resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
-			"integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ=="
+			"integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==",
+			"license": "MIT"
 		},
 		"node_modules/simple-update-notifier": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
 			"integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"semver": "^7.5.3"
 			},
@@ -1854,6 +1898,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
 			"integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+			"license": "MIT",
 			"dependencies": {
 				"memory-pager": "^1.0.2"
 			}
@@ -1862,6 +1907,7 @@
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/strife.js/-/strife.js-4.1.5.tgz",
 			"integrity": "sha512-AWjJTDT3hwuqVenSXT9ZqA0E9mx+kXwD6tJEhPbLTl20VVpfAQOyYQSDskg0cqYazUTTqlwiCwTd2Iea7snWVw==",
+			"license": "MIT",
 			"dependencies": {
 				"serialize-error": "11.0.3"
 			},
@@ -1878,6 +1924,7 @@
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^3.0.0"
 			},
@@ -1890,6 +1937,7 @@
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"is-number": "^7.0.0"
 			},
@@ -1902,6 +1950,7 @@
 			"resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
 			"integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
 			"dev": true,
+			"license": "ISC",
 			"bin": {
 				"nodetouch": "bin/nodetouch.js"
 			}
@@ -1910,6 +1959,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
 			"integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+			"license": "MIT",
 			"dependencies": {
 				"punycode": "^2.3.0"
 			},
@@ -1920,17 +1970,20 @@
 		"node_modules/ts-mixer": {
 			"version": "6.0.4",
 			"resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
-			"integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="
+			"integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+			"license": "MIT"
 		},
 		"node_modules/tslib": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"license": "0BSD"
 		},
 		"node_modules/type-fest": {
 			"version": "2.19.0",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
 			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+			"license": "(MIT OR CC0-1.0)",
 			"engines": {
 				"node": ">=12.20"
 			},
@@ -1943,6 +1996,7 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
 			"integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -1955,12 +2009,14 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
 			"integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/undici": {
-			"version": "6.19.8",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-6.19.8.tgz",
-			"integrity": "sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.21.0.tgz",
+			"integrity": "sha512-BUgJXc752Kou3oOIuU1i+yZZypyZRqNPW0vqoMPl8VaoalSfeR0D8/t4iAS3yirs79SSMTxTag+ZC86uswv+Cw==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=18.17"
 			}
@@ -1968,12 +2024,14 @@
 		"node_modules/undici-types": {
 			"version": "5.26.5",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"license": "MIT"
 		},
 		"node_modules/webidl-conversions": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
 			"integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=12"
 			}
@@ -1982,6 +2040,7 @@
 			"version": "13.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
 			"integrity": "sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==",
+			"license": "MIT",
 			"dependencies": {
 				"tr46": "^4.1.1",
 				"webidl-conversions": "^7.0.0"
@@ -1994,6 +2053,7 @@
 			"version": "8.18.0",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
 			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
 			},
@@ -2009,1306 +2069,6 @@
 					"optional": true
 				}
 			}
-		}
-	},
-	"dependencies": {
-		"@discordjs/builders": {
-			"version": "1.9.1-dev.1727784293-b20346f43",
-			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.9.1-dev.1727784293-b20346f43.tgz",
-			"integrity": "sha512-CDy8PSqUiargLggQ/eRydWqTOrj1AWkDN+uUYL28/aTexjCnlZ/m4sLMCc7eAECSfBzEB5Qg6xpu68rgKGjjNw==",
-			"requires": {
-				"@discordjs/formatters": "dev",
-				"@discordjs/util": "dev",
-				"@sapphire/shapeshift": "^4.0.0",
-				"discord-api-types": "^0.37.101",
-				"fast-deep-equal": "^3.1.3",
-				"ts-mixer": "^6.0.4",
-				"tslib": "^2.6.3"
-			},
-			"dependencies": {
-				"discord-api-types": {
-					"version": "0.37.103",
-					"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.103.tgz",
-					"integrity": "sha512-r+qitxXKe2l6KFw5odPdZSSqdEou+7eNC7BfbZ7mny5Me/K06wCTeKUMVeH/YsI9+4QQudskeQ307kr/7ppQ1A=="
-				}
-			}
-		},
-		"@discordjs/collection": {
-			"version": "1.6.0-dev.1699315767-344a3f934",
-			"resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.6.0-dev.1699315767-344a3f934.tgz",
-			"integrity": "sha512-XBKQBrCzWYIvWHVGNLVlfvbSJtLzBV+bS22xhfG7mpVyfwOfXEZTHPcChEm4RTYy711MzY3MD/6vMyD+lQ7p+A=="
-		},
-		"@discordjs/formatters": {
-			"version": "0.5.0-dev.1724803866-a5afc406b",
-			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.5.0-dev.1724803866-a5afc406b.tgz",
-			"integrity": "sha512-4jXyUPQ6cxux/p4Hqi/dSig5y2VGMqGRT7fJQgairV6CQoNR4sAbrjUltVkS5cDRPj7d2/kvkYCh7lrusGulTA==",
-			"requires": {
-				"discord-api-types": "0.37.97"
-			}
-		},
-		"@discordjs/rest": {
-			"version": "2.4.0-dev.1724803854-a5afc406b",
-			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.4.0-dev.1724803854-a5afc406b.tgz",
-			"integrity": "sha512-wEqgjZQdeJhabpyqWIFv5mkVRIj0zD+jig9BeCC+ZQitC52a3W5G0MGvoRRdmRYPW3nE2f2nhJedjY/cJ5Wc1A==",
-			"requires": {
-				"@discordjs/collection": "1.6.0-dev.1699315767-344a3f934",
-				"@discordjs/util": "dev",
-				"@sapphire/async-queue": "^1.5.3",
-				"@sapphire/snowflake": "^3.5.3",
-				"@vladfrangu/async_event_emitter": "^2.4.6",
-				"discord-api-types": "0.37.97",
-				"magic-bytes.js": "^1.10.0",
-				"tslib": "^2.6.3",
-				"undici": "6.19.8"
-			},
-			"dependencies": {
-				"@sapphire/snowflake": {
-					"version": "3.5.3",
-					"resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
-					"integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ=="
-				}
-			}
-		},
-		"@discordjs/util": {
-			"version": "1.1.1-dev.1724803860-a5afc406b",
-			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.1-dev.1724803860-a5afc406b.tgz",
-			"integrity": "sha512-v0/HLJgNAX1C3SISnQ6Z5lpQ7+NrsdWCR+QoVnVbDUqLGmeCZD7iegLby4uUemasxTFXVM6SdQrNUM9lAiEEvw=="
-		},
-		"@mongodb-js/saslprep": {
-			"version": "1.1.9",
-			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.9.tgz",
-			"integrity": "sha512-tVkljjeEaAhCqTzajSdgbQ6gE6f3oneVwa3iXR6csiEwXXOFsiC6Uh9iAjAhXPtqa/XMDHWjjeNH/77m/Yq2dw==",
-			"requires": {
-				"sparse-bitfield": "^3.0.3"
-			}
-		},
-		"@redguy12/prettier-config": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@redguy12/prettier-config/-/prettier-config-3.0.2.tgz",
-			"integrity": "sha512-MJ8xV9ntgtpqsu9xXryY9WbADXxXRxf1AvsoQuWeH+uVGQD/E+65HXNKO2BcArbb6b8AIIh6/NF9NejMoy4wdQ==",
-			"dev": true,
-			"requires": {
-				"prettier-plugin-ini": "1.2.0",
-				"prettier-plugin-jsdoc": "1.3.0",
-				"prettier-plugin-packagejson": "2.5.0"
-			},
-			"dependencies": {
-				"@nodelib/fs.scandir": {
-					"version": "2.1.5",
-					"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-					"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-					"dev": true,
-					"requires": {
-						"@nodelib/fs.stat": "2.0.5",
-						"run-parallel": "^1.1.9"
-					}
-				},
-				"@nodelib/fs.stat": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-					"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-					"dev": true
-				},
-				"@nodelib/fs.walk": {
-					"version": "1.2.8",
-					"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-					"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-					"dev": true,
-					"requires": {
-						"@nodelib/fs.scandir": "2.1.5",
-						"fastq": "^1.6.0"
-					}
-				},
-				"@pkgr/core": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
-					"integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
-					"dev": true
-				},
-				"@types/debug": {
-					"version": "4.1.12",
-					"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
-					"integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
-					"dev": true,
-					"requires": {
-						"@types/ms": "*"
-					}
-				},
-				"@types/mdast": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
-					"integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
-					"dev": true,
-					"requires": {
-						"@types/unist": "*"
-					}
-				},
-				"@types/ms": {
-					"version": "0.7.34",
-					"resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
-					"integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==",
-					"dev": true
-				},
-				"@types/unist": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
-					"integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==",
-					"dev": true
-				},
-				"binary-searching": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/binary-searching/-/binary-searching-2.0.5.tgz",
-					"integrity": "sha512-v4N2l3RxL+m4zDxyxz3Ne2aTmiPn8ZUpKFpdPtO+ItW1NcTCXA7JeHG5GMBSvoKSkQZ9ycS+EouDVxYB9ufKWA==",
-					"dev": true
-				},
-				"braces": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-					"dev": true,
-					"requires": {
-						"fill-range": "^7.0.1"
-					}
-				},
-				"character-entities": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
-					"integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
-					"dev": true
-				},
-				"comment-parser": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
-					"integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
-					"dev": true
-				},
-				"debug": {
-					"version": "4.3.4",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"decode-named-character-reference": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
-					"integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
-					"dev": true,
-					"requires": {
-						"character-entities": "^2.0.0"
-					}
-				},
-				"dequal": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-					"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-					"dev": true
-				},
-				"detect-indent": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-7.0.1.tgz",
-					"integrity": "sha512-Mc7QhQ8s+cLrnUfU/Ji94vG/r8M26m8f++vyres4ZoojaRDpZ1eSIh/EpzLNwlWuvzSZ3UbDFspjFvTDXe6e/g==",
-					"dev": true
-				},
-				"detect-newline": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-4.0.1.tgz",
-					"integrity": "sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==",
-					"dev": true
-				},
-				"devlop": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
-					"integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
-					"dev": true,
-					"requires": {
-						"dequal": "^2.0.0"
-					}
-				},
-				"dir-glob": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-					"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-					"dev": true,
-					"requires": {
-						"path-type": "^4.0.0"
-					}
-				},
-				"fast-glob": {
-					"version": "3.3.2",
-					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-					"integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
-					"dev": true,
-					"requires": {
-						"@nodelib/fs.stat": "^2.0.2",
-						"@nodelib/fs.walk": "^1.2.3",
-						"glob-parent": "^5.1.2",
-						"merge2": "^1.3.0",
-						"micromatch": "^4.0.4"
-					}
-				},
-				"fastq": {
-					"version": "1.17.1",
-					"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
-					"integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
-					"dev": true,
-					"requires": {
-						"reusify": "^1.0.4"
-					}
-				},
-				"fill-range": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-					"dev": true,
-					"requires": {
-						"to-regex-range": "^5.0.1"
-					}
-				},
-				"get-stdin": {
-					"version": "9.0.0",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-9.0.0.tgz",
-					"integrity": "sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==",
-					"dev": true
-				},
-				"git-hooks-list": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-3.1.0.tgz",
-					"integrity": "sha512-LF8VeHeR7v+wAbXqfgRlTSX/1BJR9Q1vEMR8JAz1cEg6GX07+zyj3sAdDvYjj/xnlIfVuGgj4qBei1K3hKH+PA==",
-					"dev": true
-				},
-				"glob-parent": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-					"dev": true,
-					"requires": {
-						"is-glob": "^4.0.1"
-					}
-				},
-				"globby": {
-					"version": "13.2.2",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
-					"integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
-					"dev": true,
-					"requires": {
-						"dir-glob": "^3.0.1",
-						"fast-glob": "^3.3.0",
-						"ignore": "^5.2.4",
-						"merge2": "^1.4.1",
-						"slash": "^4.0.0"
-					}
-				},
-				"ignore": {
-					"version": "5.3.1",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-					"integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
-					"dev": true
-				},
-				"is-extglob": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-					"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-					"dev": true
-				},
-				"is-glob": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-					"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^2.1.1"
-					}
-				},
-				"is-number": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-					"dev": true
-				},
-				"is-plain-obj": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-					"integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-					"dev": true
-				},
-				"lru-cache": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-					"dev": true,
-					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"mdast-util-from-markdown": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.0.tgz",
-					"integrity": "sha512-n7MTOr/z+8NAX/wmhhDji8O3bRvPTV/U0oTCaZJkjhPSKTPhS3xufVhKGF8s1pJ7Ox4QgoIU7KHseh09S+9rTA==",
-					"dev": true,
-					"requires": {
-						"@types/mdast": "^4.0.0",
-						"@types/unist": "^3.0.0",
-						"decode-named-character-reference": "^1.0.0",
-						"devlop": "^1.0.0",
-						"mdast-util-to-string": "^4.0.0",
-						"micromark": "^4.0.0",
-						"micromark-util-decode-numeric-character-reference": "^2.0.0",
-						"micromark-util-decode-string": "^2.0.0",
-						"micromark-util-normalize-identifier": "^2.0.0",
-						"micromark-util-symbol": "^2.0.0",
-						"micromark-util-types": "^2.0.0",
-						"unist-util-stringify-position": "^4.0.0"
-					}
-				},
-				"mdast-util-to-string": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
-					"integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
-					"dev": true,
-					"requires": {
-						"@types/mdast": "^4.0.0"
-					}
-				},
-				"merge2": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-					"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-					"dev": true
-				},
-				"micromark": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.0.tgz",
-					"integrity": "sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==",
-					"dev": true,
-					"requires": {
-						"@types/debug": "^4.0.0",
-						"debug": "^4.0.0",
-						"decode-named-character-reference": "^1.0.0",
-						"devlop": "^1.0.0",
-						"micromark-core-commonmark": "^2.0.0",
-						"micromark-factory-space": "^2.0.0",
-						"micromark-util-character": "^2.0.0",
-						"micromark-util-chunked": "^2.0.0",
-						"micromark-util-combine-extensions": "^2.0.0",
-						"micromark-util-decode-numeric-character-reference": "^2.0.0",
-						"micromark-util-encode": "^2.0.0",
-						"micromark-util-normalize-identifier": "^2.0.0",
-						"micromark-util-resolve-all": "^2.0.0",
-						"micromark-util-sanitize-uri": "^2.0.0",
-						"micromark-util-subtokenize": "^2.0.0",
-						"micromark-util-symbol": "^2.0.0",
-						"micromark-util-types": "^2.0.0"
-					}
-				},
-				"micromark-core-commonmark": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.0.tgz",
-					"integrity": "sha512-jThOz/pVmAYUtkroV3D5c1osFXAMv9e0ypGDOIZuCeAe91/sD6BoE2Sjzt30yuXtwOYUmySOhMas/PVyh02itA==",
-					"dev": true,
-					"requires": {
-						"decode-named-character-reference": "^1.0.0",
-						"devlop": "^1.0.0",
-						"micromark-factory-destination": "^2.0.0",
-						"micromark-factory-label": "^2.0.0",
-						"micromark-factory-space": "^2.0.0",
-						"micromark-factory-title": "^2.0.0",
-						"micromark-factory-whitespace": "^2.0.0",
-						"micromark-util-character": "^2.0.0",
-						"micromark-util-chunked": "^2.0.0",
-						"micromark-util-classify-character": "^2.0.0",
-						"micromark-util-html-tag-name": "^2.0.0",
-						"micromark-util-normalize-identifier": "^2.0.0",
-						"micromark-util-resolve-all": "^2.0.0",
-						"micromark-util-subtokenize": "^2.0.0",
-						"micromark-util-symbol": "^2.0.0",
-						"micromark-util-types": "^2.0.0"
-					}
-				},
-				"micromark-factory-destination": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.0.tgz",
-					"integrity": "sha512-j9DGrQLm/Uhl2tCzcbLhy5kXsgkHUrjJHg4fFAeoMRwJmJerT9aw4FEhIbZStWN8A3qMwOp1uzHr4UL8AInxtA==",
-					"dev": true,
-					"requires": {
-						"micromark-util-character": "^2.0.0",
-						"micromark-util-symbol": "^2.0.0",
-						"micromark-util-types": "^2.0.0"
-					}
-				},
-				"micromark-factory-label": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.0.tgz",
-					"integrity": "sha512-RR3i96ohZGde//4WSe/dJsxOX6vxIg9TimLAS3i4EhBAFx8Sm5SmqVfR8E87DPSR31nEAjZfbt91OMZWcNgdZw==",
-					"dev": true,
-					"requires": {
-						"devlop": "^1.0.0",
-						"micromark-util-character": "^2.0.0",
-						"micromark-util-symbol": "^2.0.0",
-						"micromark-util-types": "^2.0.0"
-					}
-				},
-				"micromark-factory-space": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz",
-					"integrity": "sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==",
-					"dev": true,
-					"requires": {
-						"micromark-util-character": "^2.0.0",
-						"micromark-util-types": "^2.0.0"
-					}
-				},
-				"micromark-factory-title": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.0.tgz",
-					"integrity": "sha512-jY8CSxmpWLOxS+t8W+FG3Xigc0RDQA9bKMY/EwILvsesiRniiVMejYTE4wumNc2f4UbAa4WsHqe3J1QS1sli+A==",
-					"dev": true,
-					"requires": {
-						"micromark-factory-space": "^2.0.0",
-						"micromark-util-character": "^2.0.0",
-						"micromark-util-symbol": "^2.0.0",
-						"micromark-util-types": "^2.0.0"
-					}
-				},
-				"micromark-factory-whitespace": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.0.tgz",
-					"integrity": "sha512-28kbwaBjc5yAI1XadbdPYHX/eDnqaUFVikLwrO7FDnKG7lpgxnvk/XGRhX/PN0mOZ+dBSZ+LgunHS+6tYQAzhA==",
-					"dev": true,
-					"requires": {
-						"micromark-factory-space": "^2.0.0",
-						"micromark-util-character": "^2.0.0",
-						"micromark-util-symbol": "^2.0.0",
-						"micromark-util-types": "^2.0.0"
-					}
-				},
-				"micromark-util-character": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
-					"integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
-					"dev": true,
-					"requires": {
-						"micromark-util-symbol": "^2.0.0",
-						"micromark-util-types": "^2.0.0"
-					}
-				},
-				"micromark-util-chunked": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.0.tgz",
-					"integrity": "sha512-anK8SWmNphkXdaKgz5hJvGa7l00qmcaUQoMYsBwDlSKFKjc6gjGXPDw3FNL3Nbwq5L8gE+RCbGqTw49FK5Qyvg==",
-					"dev": true,
-					"requires": {
-						"micromark-util-symbol": "^2.0.0"
-					}
-				},
-				"micromark-util-classify-character": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.0.tgz",
-					"integrity": "sha512-S0ze2R9GH+fu41FA7pbSqNWObo/kzwf8rN/+IGlW/4tC6oACOs8B++bh+i9bVyNnwCcuksbFwsBme5OCKXCwIw==",
-					"dev": true,
-					"requires": {
-						"micromark-util-character": "^2.0.0",
-						"micromark-util-symbol": "^2.0.0",
-						"micromark-util-types": "^2.0.0"
-					}
-				},
-				"micromark-util-combine-extensions": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.0.tgz",
-					"integrity": "sha512-vZZio48k7ON0fVS3CUgFatWHoKbbLTK/rT7pzpJ4Bjp5JjkZeasRfrS9wsBdDJK2cJLHMckXZdzPSSr1B8a4oQ==",
-					"dev": true,
-					"requires": {
-						"micromark-util-chunked": "^2.0.0",
-						"micromark-util-types": "^2.0.0"
-					}
-				},
-				"micromark-util-decode-numeric-character-reference": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.1.tgz",
-					"integrity": "sha512-bmkNc7z8Wn6kgjZmVHOX3SowGmVdhYS7yBpMnuMnPzDq/6xwVA604DuOXMZTO1lvq01g+Adfa0pE2UKGlxL1XQ==",
-					"dev": true,
-					"requires": {
-						"micromark-util-symbol": "^2.0.0"
-					}
-				},
-				"micromark-util-decode-string": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.0.tgz",
-					"integrity": "sha512-r4Sc6leeUTn3P6gk20aFMj2ntPwn6qpDZqWvYmAG6NgvFTIlj4WtrAudLi65qYoaGdXYViXYw2pkmn7QnIFasA==",
-					"dev": true,
-					"requires": {
-						"decode-named-character-reference": "^1.0.0",
-						"micromark-util-character": "^2.0.0",
-						"micromark-util-decode-numeric-character-reference": "^2.0.0",
-						"micromark-util-symbol": "^2.0.0"
-					}
-				},
-				"micromark-util-encode": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
-					"integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==",
-					"dev": true
-				},
-				"micromark-util-html-tag-name": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.0.tgz",
-					"integrity": "sha512-xNn4Pqkj2puRhKdKTm8t1YHC/BAjx6CEwRFXntTaRf/x16aqka6ouVoutm+QdkISTlT7e2zU7U4ZdlDLJd2Mcw==",
-					"dev": true
-				},
-				"micromark-util-normalize-identifier": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.0.tgz",
-					"integrity": "sha512-2xhYT0sfo85FMrUPtHcPo2rrp1lwbDEEzpx7jiH2xXJLqBuy4H0GgXk5ToU8IEwoROtXuL8ND0ttVa4rNqYK3w==",
-					"dev": true,
-					"requires": {
-						"micromark-util-symbol": "^2.0.0"
-					}
-				},
-				"micromark-util-resolve-all": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.0.tgz",
-					"integrity": "sha512-6KU6qO7DZ7GJkaCgwBNtplXCvGkJToU86ybBAUdavvgsCiG8lSSvYxr9MhwmQ+udpzywHsl4RpGJsYWG1pDOcA==",
-					"dev": true,
-					"requires": {
-						"micromark-util-types": "^2.0.0"
-					}
-				},
-				"micromark-util-sanitize-uri": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
-					"integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
-					"dev": true,
-					"requires": {
-						"micromark-util-character": "^2.0.0",
-						"micromark-util-encode": "^2.0.0",
-						"micromark-util-symbol": "^2.0.0"
-					}
-				},
-				"micromark-util-subtokenize": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.0.tgz",
-					"integrity": "sha512-vc93L1t+gpR3p8jxeVdaYlbV2jTYteDje19rNSS/H5dlhxUYll5Fy6vJ2cDwP8RnsXi818yGty1ayP55y3W6fg==",
-					"dev": true,
-					"requires": {
-						"devlop": "^1.0.0",
-						"micromark-util-chunked": "^2.0.0",
-						"micromark-util-symbol": "^2.0.0",
-						"micromark-util-types": "^2.0.0"
-					}
-				},
-				"micromark-util-symbol": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
-					"integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
-					"dev": true
-				},
-				"micromark-util-types": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
-					"integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
-					"dev": true
-				},
-				"micromatch": {
-					"version": "4.0.5",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-					"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-					"dev": true,
-					"requires": {
-						"braces": "^3.0.2",
-						"picomatch": "^2.3.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				},
-				"path-type": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-					"dev": true
-				},
-				"picomatch": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-					"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-					"dev": true
-				},
-				"prettier": {
-					"version": "3.3.2",
-					"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
-					"integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
-					"dev": true
-				},
-				"prettier-plugin-ini": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/prettier-plugin-ini/-/prettier-plugin-ini-1.2.0.tgz",
-					"integrity": "sha512-8RR2n3AGlObQ11NCpyvv1N+xkTe/RdGp1vko8xeuXubWUa9NrOEZMX463H1AvnhnUX8b1NeJk3TKFkgvWunApg==",
-					"dev": true,
-					"requires": {
-						"prettier": ">=3.0.0-alpha.3"
-					}
-				},
-				"prettier-plugin-jsdoc": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/prettier-plugin-jsdoc/-/prettier-plugin-jsdoc-1.3.0.tgz",
-					"integrity": "sha512-cQm8xIa0fN9ieJFMXACQd6JPycl+8ouOijAqUqu44EF/s4fXL3Wi9sKXuEaodsEWgCN42Xby/bNhqgM1iWx4uw==",
-					"dev": true,
-					"requires": {
-						"binary-searching": "^2.0.5",
-						"comment-parser": "^1.4.0",
-						"mdast-util-from-markdown": "^2.0.0"
-					}
-				},
-				"prettier-plugin-packagejson": {
-					"version": "2.5.0",
-					"resolved": "https://registry.npmjs.org/prettier-plugin-packagejson/-/prettier-plugin-packagejson-2.5.0.tgz",
-					"integrity": "sha512-6XkH3rpin5QEQodBSVNg+rBo4r91g/1mCaRwS1YGdQJZ6jwqrg2UchBsIG9tpS1yK1kNBvOt84OILsX8uHzBGg==",
-					"dev": true,
-					"requires": {
-						"sort-package-json": "2.10.0",
-						"synckit": "0.9.0"
-					}
-				},
-				"queue-microtask": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-					"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-					"dev": true
-				},
-				"reusify": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-					"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-					"dev": true
-				},
-				"run-parallel": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-					"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-					"dev": true,
-					"requires": {
-						"queue-microtask": "^1.2.2"
-					}
-				},
-				"semver": {
-					"version": "7.6.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-					"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				},
-				"slash": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-					"integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
-					"dev": true
-				},
-				"sort-object-keys": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-1.1.3.tgz",
-					"integrity": "sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==",
-					"dev": true
-				},
-				"sort-package-json": {
-					"version": "2.10.0",
-					"resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-2.10.0.tgz",
-					"integrity": "sha512-MYecfvObMwJjjJskhxYfuOADkXp1ZMMnCFC8yhp+9HDsk7HhR336hd7eiBs96lTXfiqmUNI+WQCeCMRBhl251g==",
-					"dev": true,
-					"requires": {
-						"detect-indent": "^7.0.1",
-						"detect-newline": "^4.0.0",
-						"get-stdin": "^9.0.0",
-						"git-hooks-list": "^3.0.0",
-						"globby": "^13.1.2",
-						"is-plain-obj": "^4.1.0",
-						"semver": "^7.6.0",
-						"sort-object-keys": "^1.1.3"
-					}
-				},
-				"synckit": {
-					"version": "0.9.0",
-					"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.0.tgz",
-					"integrity": "sha512-7RnqIMq572L8PeEzKeBINYEJDDxpcH8JEgLwUqBd3TkofhFRbkq4QLR0u+36avGAhCRbk2nnmjcW9SE531hPDg==",
-					"dev": true,
-					"requires": {
-						"@pkgr/core": "^0.1.0",
-						"tslib": "^2.6.2"
-					}
-				},
-				"to-regex-range": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-					"dev": true,
-					"requires": {
-						"is-number": "^7.0.0"
-					}
-				},
-				"tslib": {
-					"version": "2.6.2",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-					"dev": true
-				},
-				"unist-util-stringify-position": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
-					"integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
-					"dev": true,
-					"requires": {
-						"@types/unist": "^3.0.0"
-					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
-				}
-			}
-		},
-		"@sapphire/async-queue": {
-			"version": "1.5.3",
-			"resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.3.tgz",
-			"integrity": "sha512-x7zadcfJGxFka1Q3f8gCts1F0xMwCKbZweM85xECGI0hBTeIZJGGCrHgLggihBoprlQ/hBmDR5LKfIPqnmHM3w=="
-		},
-		"@sapphire/shapeshift": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
-			"integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
-			"requires": {
-				"fast-deep-equal": "^3.1.3",
-				"lodash": "^4.17.21"
-			}
-		},
-		"@total-typescript/ts-reset": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/@total-typescript/ts-reset/-/ts-reset-0.6.1.tgz",
-			"integrity": "sha512-cka47fVSo6lfQDIATYqb/vO1nvFfbPw7uWLayIXIhGETj0wcOOlrlkobOMDNQOFr9QOafegUPq13V2+6vtD7yg==",
-			"dev": true
-		},
-		"@types/node": {
-			"version": "20.10.8",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.8.tgz",
-			"integrity": "sha512-f8nQs3cLxbAFc00vEU59yf9UyGUftkPaLGfvbVOIDdx2i1b8epBqj2aNGyP19fiyXWvlmZ7qC1XLjAzw/OKIeA==",
-			"requires": {
-				"undici-types": "~5.26.4"
-			}
-		},
-		"@types/webidl-conversions": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
-			"integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="
-		},
-		"@types/whatwg-url": {
-			"version": "11.0.5",
-			"resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
-			"integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
-			"requires": {
-				"@types/webidl-conversions": "*"
-			}
-		},
-		"@types/ws": {
-			"version": "8.5.12",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.12.tgz",
-			"integrity": "sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==",
-			"requires": {
-				"@types/node": "*"
-			}
-		},
-		"@vladfrangu/async_event_emitter": {
-			"version": "2.4.6",
-			"resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.6.tgz",
-			"integrity": "sha512-RaI5qZo6D2CVS6sTHFKg1v5Ohq/+Bo2LZ5gzUEwZ/WkHhwtGTCB/sVLw8ijOkAUxasZ+WshN/Rzj4ywsABJ5ZA=="
-		},
-		"anymatch": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-			"dev": true,
-			"requires": {
-				"normalize-path": "^3.0.0",
-				"picomatch": "^2.0.4"
-			}
-		},
-		"balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true
-		},
-		"binary-extensions": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-			"integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-			"dev": true
-		},
-		"brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
-			"requires": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"braces": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-			"dev": true,
-			"requires": {
-				"fill-range": "^7.1.1"
-			}
-		},
-		"bson": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/bson/-/bson-6.9.0.tgz",
-			"integrity": "sha512-X9hJeyeM0//Fus+0pc5dSUMhhrrmWwQUtdavaQeF3Ta6m69matZkGWV/MrBcnwUeLC8W9kwwc2hfkZgUuCX3Ig=="
-		},
-		"chokidar": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-			"integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-			"dev": true,
-			"requires": {
-				"anymatch": "~3.1.2",
-				"braces": "~3.0.2",
-				"fsevents": "~2.3.2",
-				"glob-parent": "~5.1.2",
-				"is-binary-path": "~2.1.0",
-				"is-glob": "~4.0.1",
-				"normalize-path": "~3.0.0",
-				"readdirp": "~3.6.0"
-			}
-		},
-		"concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-			"dev": true
-		},
-		"debug": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-			"integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
-			"requires": {
-				"ms": "2.1.2"
-			},
-			"dependencies": {
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-				}
-			}
-		},
-		"discord-api-types": {
-			"version": "0.37.97",
-			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.97.tgz",
-			"integrity": "sha512-No1BXPcVkyVD4ZVmbNgDKaBoqgeQ+FJpzZ8wqHkfmBnTZig1FcH3iPPersiK1TUIAzgClh2IvOuVUYfcWLQAOA=="
-		},
-		"discord.js": {
-			"version": "14.16.0-dev.1724544741-437437461",
-			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.16.0-dev.1724544741-437437461.tgz",
-			"requires": {
-				"@discordjs/builders": "1.9.1-dev.1727784293-b20346f43",
-				"@discordjs/collection": "1.6.0-dev.1699315767-344a3f934",
-				"@discordjs/formatters": "dev",
-				"@discordjs/rest": "dev",
-				"@discordjs/util": "dev",
-				"@discordjs/ws": "1.2.0-dev.1721822666-fcd35ea2e",
-				"@sapphire/snowflake": "3.5.3",
-				"discord-api-types": "0.37.97",
-				"fast-deep-equal": "3.1.3",
-				"lodash.snakecase": "4.1.1",
-				"tslib": "^2.6.3",
-				"undici": "6.19.8"
-			},
-			"dependencies": {
-				"@discordjs/ws": {
-					"version": "1.2.0-dev.1721822666-fcd35ea2e",
-					"resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.0-dev.1721822666-fcd35ea2e.tgz",
-					"integrity": "sha512-AEck4R1oBztXXoRsVW8mYj8ZLJHSzo1W+erbHmatLk/qHWV3ni2mtCpGWM+j1OePLO4Ab9ii1K5kgW7WfeFgsQ==",
-					"requires": {
-						"@discordjs/collection": "1.6.0-dev.1699315767-344a3f934",
-						"@discordjs/rest": "dev",
-						"@discordjs/util": "dev",
-						"@sapphire/async-queue": "^1.5.2",
-						"@types/ws": "^8.5.10",
-						"@vladfrangu/async_event_emitter": "^2.2.4",
-						"discord-api-types": "0.37.90",
-						"tslib": "^2.6.2",
-						"ws": "^8.17.0"
-					},
-					"dependencies": {
-						"discord-api-types": {
-							"version": "0.37.90",
-							"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.90.tgz",
-							"integrity": "sha512-lpOJSGrqHuXoM4FV/2HtjoaJpCClGFHpRNIdZEW8zPINlsCHNSfIwA2EQ8dxeE6k1QhhTuM9ZlOGVYXoU7FLgA=="
-						}
-					}
-				},
-				"@sapphire/snowflake": {
-					"version": "3.5.3",
-					"resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
-					"integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ=="
-				}
-			}
-		},
-		"fast-deep-equal": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-		},
-		"fill-range": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-			"dev": true,
-			"requires": {
-				"to-regex-range": "^5.0.1"
-			}
-		},
-		"fsevents": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-			"dev": true,
-			"optional": true
-		},
-		"glob-parent": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-			"dev": true,
-			"requires": {
-				"is-glob": "^4.0.1"
-			}
-		},
-		"has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-			"dev": true
-		},
-		"ignore-by-default": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-			"integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
-			"dev": true
-		},
-		"is-binary-path": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-			"dev": true,
-			"requires": {
-				"binary-extensions": "^2.0.0"
-			}
-		},
-		"is-extglob": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-			"dev": true
-		},
-		"is-glob": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-			"dev": true,
-			"requires": {
-				"is-extglob": "^2.1.1"
-			}
-		},
-		"is-number": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"dev": true
-		},
-		"kareem": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
-			"integrity": "sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q=="
-		},
-		"lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-		},
-		"lodash.snakecase": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
-			"integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
-		},
-		"magic-bytes.js": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.10.0.tgz",
-			"integrity": "sha512-/k20Lg2q8LE5xiaaSkMXk4sfvI+9EGEykFS4b0CHHGWqDYU0bGUFSwchNOMA56D7TCs9GwVTkqe9als1/ns8UQ=="
-		},
-		"memory-pager": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
-			"integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="
-		},
-		"minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"requires": {
-				"brace-expansion": "^1.1.7"
-			}
-		},
-		"mongodb": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.10.0.tgz",
-			"integrity": "sha512-gP9vduuYWb9ZkDM546M+MP2qKVk5ZG2wPF63OvSRuUbqCR+11ZCAE1mOfllhlAG0wcoJY5yDL/rV3OmYEwXIzg==",
-			"requires": {
-				"@mongodb-js/saslprep": "^1.1.5",
-				"bson": "^6.7.0",
-				"mongodb-connection-string-url": "^3.0.0"
-			}
-		},
-		"mongodb-connection-string-url": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.1.tgz",
-			"integrity": "sha512-XqMGwRX0Lgn05TDB4PyG2h2kKO/FfWJyCzYQbIhXUxz7ETt0I/FqHjUeqj37irJ+Dl1ZtU82uYyj14u2XsZKfg==",
-			"requires": {
-				"@types/whatwg-url": "^11.0.2",
-				"whatwg-url": "^13.0.0"
-			}
-		},
-		"mongoose": {
-			"version": "8.8.3",
-			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.8.3.tgz",
-			"integrity": "sha512-/I4n/DcXqXyIiLRfAmUIiTjj3vXfeISke8dt4U4Y8Wfm074Wa6sXnQrXN49NFOFf2mM1kUdOXryoBvkuCnr+Qw==",
-			"requires": {
-				"bson": "^6.7.0",
-				"kareem": "2.6.3",
-				"mongodb": "~6.10.0",
-				"mpath": "0.9.0",
-				"mquery": "5.0.0",
-				"ms": "2.1.3",
-				"sift": "17.1.3"
-			}
-		},
-		"mpath": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
-			"integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew=="
-		},
-		"mquery": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
-			"integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
-			"requires": {
-				"debug": "4.x"
-			}
-		},
-		"ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-		},
-		"nodemon": {
-			"version": "3.1.7",
-			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.7.tgz",
-			"integrity": "sha512-hLj7fuMow6f0lbB0cD14Lz2xNjwsyruH251Pk4t/yIitCFJbmY1myuLlHm/q06aST4jg6EgAh74PIBBrRqpVAQ==",
-			"dev": true,
-			"requires": {
-				"chokidar": "^3.5.2",
-				"debug": "^4",
-				"ignore-by-default": "^1.0.1",
-				"minimatch": "^3.1.2",
-				"pstree.remy": "^1.1.8",
-				"semver": "^7.5.3",
-				"simple-update-notifier": "^2.0.0",
-				"supports-color": "^5.5.0",
-				"touch": "^3.1.0",
-				"undefsafe": "^2.0.5"
-			}
-		},
-		"normalize-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-			"dev": true
-		},
-		"picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-			"dev": true
-		},
-		"prettier": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
-			"integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
-			"dev": true
-		},
-		"pstree.remy": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
-			"integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
-			"dev": true
-		},
-		"punycode": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
-		},
-		"readdirp": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-			"dev": true,
-			"requires": {
-				"picomatch": "^2.2.1"
-			}
-		},
-		"semver": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-			"dev": true
-		},
-		"serialize-error": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-11.0.3.tgz",
-			"integrity": "sha512-2G2y++21dhj2R7iHAdd0FIzjGwuKZld+7Pl/bTU6YIkrC2ZMbVUjm+luj6A6V34Rv9XfKJDKpTWu9W4Gse1D9g==",
-			"requires": {
-				"type-fest": "^2.12.2"
-			}
-		},
-		"sift": {
-			"version": "17.1.3",
-			"resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
-			"integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ=="
-		},
-		"simple-update-notifier": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
-			"integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
-			"dev": true,
-			"requires": {
-				"semver": "^7.5.3"
-			}
-		},
-		"sparse-bitfield": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
-			"integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
-			"requires": {
-				"memory-pager": "^1.0.2"
-			}
-		},
-		"strife.js": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/strife.js/-/strife.js-4.1.5.tgz",
-			"integrity": "sha512-AWjJTDT3hwuqVenSXT9ZqA0E9mx+kXwD6tJEhPbLTl20VVpfAQOyYQSDskg0cqYazUTTqlwiCwTd2Iea7snWVw==",
-			"requires": {
-				"serialize-error": "11.0.3"
-			}
-		},
-		"supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
-			"requires": {
-				"has-flag": "^3.0.0"
-			}
-		},
-		"to-regex-range": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-			"dev": true,
-			"requires": {
-				"is-number": "^7.0.0"
-			}
-		},
-		"touch": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
-			"integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
-			"dev": true
-		},
-		"tr46": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
-			"integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
-			"requires": {
-				"punycode": "^2.3.0"
-			}
-		},
-		"ts-mixer": {
-			"version": "6.0.4",
-			"resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
-			"integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="
-		},
-		"tslib": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
-		},
-		"type-fest": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-		},
-		"typescript": {
-			"version": "5.4.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-			"integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-			"dev": true
-		},
-		"undefsafe": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
-			"integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
-			"dev": true
-		},
-		"undici": {
-			"version": "6.19.8",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-6.19.8.tgz",
-			"integrity": "sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g=="
-		},
-		"undici-types": {
-			"version": "5.26.5",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
-		},
-		"webidl-conversions": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-			"integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
-		},
-		"whatwg-url": {
-			"version": "13.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
-			"integrity": "sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==",
-			"requires": {
-				"tr46": "^4.1.1",
-				"webidl-conversions": "^7.0.0"
-			}
-		},
-		"ws": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-			"requires": {}
 		}
 	}
 }


### PR DESCRIPTION
<details><summary>Changed dependencies</summary>

- Bumped [`@discordjs/formatters@0.5.0-dev.1724803866-a5afc406b`](https://npmjs.com/package/@discordjs/formatters/v/0.5.0-dev.1724803866-a5afc406b) to [`1.0.0-dev.1732795526-2b0944a92`](https://npmjs.com/package/@discordjs/formatters/v/1.0.0-dev.1732795526-2b0944a92) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/formatters))
- Bumped [`@discordjs/rest@2.4.0-dev.1724803854-a5afc406b`](https://npmjs.com/package/@discordjs/rest/v/2.4.0-dev.1724803854-a5afc406b) to [`3.0.0-dev.1732795513-2b0944a92`](https://npmjs.com/package/@discordjs/rest/v/3.0.0-dev.1732795513-2b0944a92) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/rest))
- Bumped [`@discordjs/util@1.1.1-dev.1724803860-a5afc406b`](https://npmjs.com/package/@discordjs/util/v/1.1.1-dev.1724803860-a5afc406b) to [`2.0.0-dev.1732795513-2b0944a92`](https://npmjs.com/package/@discordjs/util/v/2.0.0-dev.1732795513-2b0944a92) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/util))
- Installed [`@discordjs/ws@1.2.0-dev.1721822666-fcd35ea2e`](https://npmjs.com/package/@discordjs/ws/v/1.2.0-dev.1721822666-fcd35ea2e)
- Installed [`discord-api-types@0.37.90`](https://npmjs.com/package/discord-api-types/v/0.37.90)
- Bumped [`@sapphire/async-queue@1.5.3`](https://npmjs.com/package/@sapphire/async-queue/v/1.5.3) to [`1.5.5`](https://npmjs.com/package/@sapphire/async-queue/v/1.5.5) ([see recent commits](https://github.com/sapphiredev/utilities/commits/HEAD/packages/async-queue))
- Installed [`@sapphire/snowflake@3.5.5`](https://npmjs.com/package/@sapphire/snowflake/v/3.5.5)
- Bumped [`@types/ws@8.5.12`](https://npmjs.com/package/@types/ws/v/8.5.12) to [`8.5.13`](https://npmjs.com/package/@types/ws/v/8.5.13) ([see recent commits](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/ws))
- Bumped [`bson@6.9.0`](https://npmjs.com/package/bson/v/6.9.0) to [`6.10.0`](https://npmjs.com/package/bson/v/6.10.0) ([see recent commits](https://github.com/mongodb/js-bson))
- Bumped [`debug@4.3.6`](https://npmjs.com/package/debug/v/4.3.6) to [`4.3.7`](https://npmjs.com/package/debug/v/4.3.7) ([see recent commits](https://github.com/debug-js/debug))
- Bumped [`discord-api-types@0.37.97`](https://npmjs.com/package/discord-api-types/v/0.37.97) to [`0.37.109`](https://npmjs.com/package/discord-api-types/v/0.37.109) ([see recent commits](https://github.com/discordjs/discord-api-types))
- Bumped [`discord.js@14.16.0-dev.1724544741-437437461`](https://npmjs.com/package/discord.js/v/14.16.0-dev.1724544741-437437461) to [`15.0.0-dev.1732795515-2b0944a92`](https://npmjs.com/package/discord.js/v/15.0.0-dev.1732795515-2b0944a92) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/discord.js))
- Bumped [`tslib@2.7.0`](https://npmjs.com/package/tslib/v/2.7.0) to [`2.8.1`](https://npmjs.com/package/tslib/v/2.8.1) ([see recent commits](https://github.com/Microsoft/tslib))
- Bumped [`undici@6.19.8`](https://npmjs.com/package/undici/v/6.19.8) to [`6.21.0`](https://npmjs.com/package/undici/v/6.21.0) ([see recent commits](https://github.com/nodejs/undici))
- Removed [`discord-api-types@0.37.103`](https://npmjs.com/package/discord-api-types/v/0.37.103)
- Removed [`@sapphire/snowflake@3.5.3`](https://npmjs.com/package/@sapphire/snowflake/v/3.5.3)
- Removed [`ms@2.1.2`](https://npmjs.com/package/ms/v/2.1.2)
- Removed [`@discordjs/ws@1.2.0-dev.1721822666-fcd35ea2e`](https://npmjs.com/package/@discordjs/ws/v/1.2.0-dev.1721822666-fcd35ea2e)
- Removed [`discord-api-types@0.37.90`](https://npmjs.com/package/discord-api-types/v/0.37.90)
</details><details><summary>Requirement changes</summary>

*No requirements changed.*
</details>
